### PR TITLE
Regex & Multi Process filtering, Xcode and XcodeColors support.

### DIFF
--- a/MobileDevice.framework
+++ b/MobileDevice.framework
@@ -1,1 +1,0 @@
-/System/Library/PrivateFrameworks/MobileDevice.framework

--- a/deviceconsole.xcodeproj/project.pbxproj
+++ b/deviceconsole.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 
 /* Begin PBXFileReference section */
 		08FB7796FE84155DC02AAC07 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		8B6CE20D1E19B11F003E38F4 /* main.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = main.h; sourceTree = "<group>"; };
 		8DD76FB20486AB0100D96B5E /* deviceconsole */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = deviceconsole; sourceTree = BUILT_PRODUCTS_DIR; };
 		945855DB140EB622009DFEA5 /* MobileDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MobileDevice.h; sourceTree = "<group>"; };
 		945856A9140EC3BA009DFEA5 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
@@ -61,6 +62,7 @@
 			children = (
 				945855DB140EB622009DFEA5 /* MobileDevice.h */,
 				08FB7796FE84155DC02AAC07 /* main.c */,
+				8B6CE20D1E19B11F003E38F4 /* main.h */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -99,6 +101,8 @@
 /* Begin PBXProject section */
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "deviceconsole" */;
 			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = English;

--- a/main.c
+++ b/main.c
@@ -327,7 +327,8 @@ int main (int argc, char * const argv[])
     int c;
     bool use_separators = false;
     bool force_color = isatty(1);
-    bool xcode_colors = (getenv("XcodeColors"));
+    bool xcode_colors = ((getenv("XcodeColors")) ? strstr(getenv("XcodeColors"), "YES") != NULL : false);
+    bool in_xcode = xcode_colors;
 
     while ((c = getopt(argc, argv, "dcxsu:p:r:")) != -1)
         switch (c)
@@ -339,7 +340,7 @@ int main (int argc, char * const argv[])
             force_color = true;
             break;
         case 'x':
-            xcode_colors = true;
+            in_xcode = true;
             break;
         case 's':
             use_separators = true;
@@ -373,7 +374,8 @@ int main (int argc, char * const argv[])
         default:
             abort();
     }
-    if (force_color || xcode_colors) {
+    
+    if ((!in_xcode && force_color) || xcode_colors) {
         set_colors(xcode_colors);
         printMessage = &write_colored;
         printSeparator = use_separators ? &color_separator : &no_separator;

--- a/main.c
+++ b/main.c
@@ -107,7 +107,6 @@ static unsigned char should_print_message(const char *buffer, size_t length)
 {
     if (length < 3) return 0; // don't want blank lines
     
-    static unsigned char last_should_print = 0;
     unsigned char should_print = 1;
     
     size_t space_offsets[3];
@@ -146,20 +145,15 @@ static unsigned char should_print_message(const char *buffer, size_t length)
                 currentProcessName = strtok(NULL, ", ");
             }
             
-            if (!should_print) {
-                last_should_print = should_print;
+            if (!should_print)
                 return should_print;
-            }
         }
         
         
         // Check whether extension name matches the list passed to -e option and filter if needed
         if (requiredExtensionNames != NULL) {
-            if (processParams.extension == NULL) {
-                last_should_print = false;
+            if (processParams.extension == NULL)
                 return false;
-            }
-            
             
             char *currentExtensionName = strtok(strdup(requiredExtensionNames), ", ");
             while (currentExtensionName != NULL) {
@@ -171,10 +165,8 @@ static unsigned char should_print_message(const char *buffer, size_t length)
                 currentExtensionName = strtok(NULL, ", ");
             }
             
-            if (!should_print) {
-                last_should_print = should_print;
+            if (!should_print)
                 return should_print;
-            }
         }
         
         free(allProcessParams);
@@ -194,7 +186,6 @@ static unsigned char should_print_message(const char *buffer, size_t length)
     
     // More filtering options can be added here and return 0 when they won't meet filter criteria
     
-    last_should_print = should_print;
     return should_print;
 }
 

--- a/main.c
+++ b/main.c
@@ -113,21 +113,21 @@ static unsigned char should_print_message(const char *buffer, size_t length)
 static void set_colors(xcode_colors) {
     COLOR_RESET         = (xcode_colors) ? "\e[;"                                       :   "\e[m";
     COLOR_NORMAL        = (xcode_colors) ? xcode_color_with_rgb("fg", 0, 0, 0)          :   "\e[0m";
-    COLOR_DARK          = (xcode_colors) ? xcode_color_with_rgb("fg", 207, 201, 189)    :   "\e[2m";
-    COLOR_RED           = (xcode_colors) ? xcode_color_with_rgb("fg", 255, 31, 2)       :   "\e[0;31m";
-    COLOR_DARK_RED      = (xcode_colors) ? xcode_color_with_rgb("fg", 148, 18, 1)       :   "\e[2;31m";
-    COLOR_GREEN         = (xcode_colors) ? xcode_color_with_rgb("fg", 2, 255, 14)       :   "\e[0;32m";
-    COLOR_DARK_GREEN    = (xcode_colors) ? xcode_color_with_rgb("fg", 1, 139, 8)        :   "\e[2;32m";
-    COLOR_YELLOW        = (xcode_colors) ? xcode_color_with_rgb("fg", 255, 228, 0)      :   "\e[0;33m";
-    COLOR_DARK_YELLOW   = (xcode_colors) ? xcode_color_with_rgb("fg", 167, 149, 1)      :   "\e[2;33m";
-    COLOR_BLUE          = (xcode_colors) ? xcode_color_with_rgb("fg", 0, 0, 255)        :   "\e[0;34m";
-    COLOR_DARK_BLUE     = (xcode_colors) ? xcode_color_with_rgb("fg", 0, 0, 100)        :   "\e[2;34m";
-    COLOR_MAGENTA       = (xcode_colors) ? xcode_color_with_rgb("fg", 213, 149, 139)    :   "\e[0;35m";
-    COLOR_DARK_MAGENTA  = (xcode_colors) ? xcode_color_with_rgb("fg", 145, 100, 165)    :   "\e[2;35m";
-    COLOR_CYAN          = (xcode_colors) ? xcode_color_with_rgb("fg", 45, 253, 255)     :   "\e[0;36m";
-    COLOR_DARK_CYAN     = (xcode_colors) ? xcode_color_with_rgb("fg", 34, 129, 128)     :   "\e[2;36m";
-    COLOR_WHITE         = (xcode_colors) ? xcode_color_with_rgb("fg", 255, 255, 255)    :   "\e[0;37m";
-    COLOR_DARK_WHITE    = (xcode_colors) ? xcode_color_with_rgb("fg", 180, 180, 180)    :   "\e[0;37m";
+    COLOR_DARK          = (xcode_colors) ? xcode_color_with_rgb("fg", 102, 102, 102)    :   "\e[2m";
+    COLOR_RED           = (xcode_colors) ? xcode_color_with_rgb("fg", 151, 4, 12)       :   "\e[0;31m";
+    COLOR_DARK_RED      = (xcode_colors) ? xcode_color_with_rgb("fg", 227, 10, 23)       :   "\e[2;31m";
+    COLOR_GREEN         = (xcode_colors) ? xcode_color_with_rgb("fg", 23, 164, 26)       :   "\e[0;32m";
+    COLOR_DARK_GREEN    = (xcode_colors) ? xcode_color_with_rgb("fg", 33, 215, 38)        :   "\e[2;32m";
+    COLOR_YELLOW        = (xcode_colors) ? xcode_color_with_rgb("fg", 153, 152, 29)      :   "\e[0;33m";
+    COLOR_DARK_YELLOW   = (xcode_colors) ? xcode_color_with_rgb("fg", 229, 228, 49)      :   "\e[2;33m";
+    COLOR_BLUE          = (xcode_colors) ? xcode_color_with_rgb("fg", 5, 22, 175)        :   "\e[0;34m";
+    COLOR_DARK_BLUE     = (xcode_colors) ? xcode_color_with_rgb("fg", 11, 36, 251)        :   "\e[2;34m";
+    COLOR_MAGENTA       = (xcode_colors) ? xcode_color_with_rgb("fg", 177, 25, 176)    :   "\e[0;35m";
+    COLOR_DARK_MAGENTA  = (xcode_colors) ? xcode_color_with_rgb("fg", 227, 25, 227)    :   "\e[2;35m";
+    COLOR_CYAN          = (xcode_colors) ? xcode_color_with_rgb("fg", 26, 166, 177)     :   "\e[0;36m";
+    COLOR_DARK_CYAN     = (xcode_colors) ? xcode_color_with_rgb("fg", 39, 229, 228)     :   "\e[2;36m";
+    COLOR_WHITE         = (xcode_colors) ? xcode_color_with_rgb("fg", 191, 191, 191)    :   "\e[0;37m";
+    COLOR_DARK_WHITE    = (xcode_colors) ? xcode_color_with_rgb("fg", 230, 229, 230)    :   "\e[0;37m";
 }
 
 static void write_colored(int fd, const char *buffer, size_t length)

--- a/main.c
+++ b/main.c
@@ -358,12 +358,17 @@ static void SocketCallback(CFSocketRef s, CFSocketCallBackType type, CFDataRef a
             should_print_result = should_print_message(buffer, extentLength);
         
         if (should_print_result) {
-            if (should_filter)
+            if (should_filter) {
+                static bool is_first_message = true;
+                if (!is_first_message)
+                    printSeparator(1);
+                else
+                    is_first_message = false;
+                
                 printMessage(1, buffer, extentLength);
+            }
             else
                 write_fully(1, buffer, extentLength);
-            
-            printSeparator(1);
         }
         
         length -= extentLength;

--- a/main.c
+++ b/main.c
@@ -321,7 +321,7 @@ static void color_separator(int fd)
 int main (int argc, char * const argv[])
 {
     if ((argc == 2) && (strcmp(argv[1], "--help") == 0)) {
-        fprintf(stderr, "Usage: %s [options]\nOptions:\n -d\t\t\tInclude connect/disconnect messages in standard out\n -u <udid>\t\tShow only logs from a specific device\n -p <process name>\tShow only logs from a specific process\n -r <regular expression>\tFilter messages by regular expression.\n\nControl-C to disconnect\nMail bug reports and suggestions to <ryan.petrich@medialets.com>\n", argv[0]);
+        fprintf(stderr, "Usage: %s [options]\nOptions:\n -d\t\t\t\tInclude connect/disconnect messages in standard out\n -u <udid>\t\t\tShow only logs from a specific device\n -p <process name>\t\tShow only logs from a specific process\n -r <regular expression>\tFilter messages by regular expression.\n -x\t\t\t\tDisable tty coloring in Xcode (unless XcodeColors intalled).\n\nControl-C to disconnect\nMail bug reports and suggestions to <ryan.petrich@medialets.com>\n", argv[0]);
         return 1;
     }
     int c;

--- a/main.c
+++ b/main.c
@@ -358,7 +358,11 @@ static void SocketCallback(CFSocketRef s, CFSocketCallBackType type, CFDataRef a
             should_print_result = should_print_message(buffer, extentLength);
         
         if (should_print_result) {
-            printMessage(1, buffer, extentLength);
+            if (should_filter)
+                printMessage(1, buffer, extentLength);
+            else
+                write_fully(1, buffer, extentLength);
+            
             printSeparator(1);
         }
         

--- a/main.h
+++ b/main.h
@@ -1,0 +1,46 @@
+#include <CoreFoundation/CoreFoundation.h>
+#include "MobileDevice.h"
+
+typedef struct {
+    service_conn_t connection;
+    CFSocketRef socket;
+    CFRunLoopSourceRef source;
+} DeviceConsoleConnection;
+
+typedef struct {
+    char *name;
+    char *pid;
+    char *extension;
+} ProcessParams, *ProcessParams_p;
+
+typedef struct {
+    char *reset;
+    char *normal;
+    char *dark;
+    char *red;
+    char *dark_red;
+    char *green;
+    char *dark_green;
+    char *yellow;
+    char *dark_yellow;
+    char *blue;
+    char *dark_blue;
+    char *magenta;
+    char *dark_magenta;
+    char *cyan;
+    char *dark_cyan;
+    char *white;
+    char *dark_white;
+} Colors, *Colors_p;
+
+typedef struct {
+    int debug;
+    CFMutableDictionaryRef liveConnections;
+    CFStringRef requiredDeviceId;
+    char *requiredProcessNames;
+    char *requiredExtensionNames;
+    bool use_regex;
+    regex_t requiredRegex;
+    void (*printMessage)(int fd, const char *, size_t);
+    void (*printSeparator)(int fd);
+} Config, *Config_p;


### PR DESCRIPTION
Regex & Multi Process filtering:
This makes tweak development a lot easier,
You can filter all injected process at once,
And show only messages produced by the injected code.

Xcode Support:
This allows using device console inside Xcode, under the "Target output", by disabling tty colors when -x is specified.

XcodeColors support:
This allows using XcodeColors plugin as the colouring engine.
Auto triggered by XcodeColors's environment variable, and also triggering the -x option.
